### PR TITLE
Support memory view in cppvsdbg debugger for windows

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,7 @@
         "codicon",
         "codicons",
         "cppdbg",
+        "cppvsdbg",
         "cspy",
         "Debouncer",
         "esbuild",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "keywords": [
         "cortex-debug",
         "cppdbg",
+        "cppvsdbg",
         "embedded",
         "memory",
         "cortex",
@@ -34,6 +35,7 @@
     "activationEvents": [
         "onDebugResolve:cortex-debug",
         "onDebugResolve:cppdbg",
+        "onDebugResolve:cppvsdbg",
         "onDebugResolve:cspy",
         "onCommand:cu-debug.memory-view.uriTest",
         "onWebviewPanel:memory-view.memoryView",

--- a/src/view/memview/debug-tracker.ts
+++ b/src/view/memview/debug-tracker.ts
@@ -19,7 +19,8 @@ let trackerApiClientInfo: IDebuggerSubscription;
 export const TrackedDebuggers = [
     'cortex-debug',
     'cppdbg',       // Microsoft debugger
-    'cspy'          // IAR debugger
+    'cspy',          // IAR debugger
+    'cppvsdbg'
 ];
 
 export interface ITrackedDebugSession {

--- a/src/view/memview/memview-doc.ts
+++ b/src/view/memview/memview-doc.ts
@@ -500,7 +500,7 @@ export class MemViewPanelProvider implements vscode.WebviewViewProvider, vscode.
                         const doc = DualViewDoc.getDocumentById(body.docId);
                         if (doc) {
                             const memCmd = (body as ICmdGetMemory);
-                            doc.getMemoryPage(BigInt(memCmd.addr), memCmd.count).then((b) => {
+                            doc.getMemoryPage(memCmd.addr, memCmd.count).then((b) => {
                                 this.postResponse(body, b);
                             });
                         } else {


### PR DESCRIPTION
In this pull request, I am adding support for **cppvsdbg** (visual studio) support for windows. 

**Why doesn't **cppvsdbg** work in memview extension ?** 
=> Memview extension is sending DEC (decimal) value of the memory address to debugger which get misinterpret by **cppvsdbg** debugger. As  debugger support hex value of the memory address, so sending hex address in DAP protocol message solve the issue. I have tested this change for "cppdbg" debugger.


DAP Specification: https://microsoft.github.io/debug-adapter-protocol/specification

https://github.com/user-attachments/assets/a0e8021a-f2ba-4be4-81ae-235edadc26df

