### PR TITLE
Add tracking of the mplab debugger

### DIFF
--- a/src/view/memview/debug-tracker.ts
+++ b/src/view/memview/debug-tracker.ts
@@ -19,7 +19,8 @@ let trackerApiClientInfo: IDebuggerSubscription;
 export const TrackedDebuggers = [
     'cortex-debug',
     'cppdbg',       // Microsoft debugger
-    'cspy'          // IAR debugger
+    'cspy',         // IAR debugger
+    'mplab-core-da' // MPLAB debugger
 ];
 
 export interface ITrackedDebugSession {


### PR DESCRIPTION
Automatically track debug sessions using the [MPLAB Debugger](https://marketplace.visualstudio.com/items?itemName=Microchip.mplab-core-da)