### PR TITLE
Support for STMicroelectronics adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please note that we are still in Preview mode. For those using the API, this can
 -   ---Selection, copy &--- paste
 -   Apply settings to workspace/user/all-views beyond the current view
 -   Scrollbars: We are not happy about the scrollbars. While scrolling works with the track-pad or mouse-wheel, the scrollbars are not always visible. We hope to have proper scrollbars in the future and soon. The infinite scrolling makes scrollbars a bit tricky. Any help is appreciated if you are a HTML/CSS/React expert.
+-   [#54](https://github.com/mcu-debug/memview/pull/54): Support for STMicroelectronics adapters
 
 ## 0.0.27 - Sep 21, 2025
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
         "onDebugResolve:cortex-debug",
         "onDebugResolve:cppdbg",
         "onDebugResolve:cspy",
+        "onDebugResolve:stlinkgdbtarget",
+        "onDebugResolve:jlinkgdbtarget",
         "onCommand:cu-debug.memory-view.uriTest",
         "onWebviewPanel:memory-view.memoryView",
         "onUri"

--- a/src/view/memview/debug-tracker.ts
+++ b/src/view/memview/debug-tracker.ts
@@ -18,9 +18,11 @@ let trackerApiClientInfo: IDebuggerSubscription;
 
 export const TrackedDebuggers = [
     'cortex-debug',
-    'cppdbg',       // Microsoft debugger
-    'cspy',         // IAR debugger
-    'mplab-core-da' // MPLAB debugger
+    'cppdbg', // Microsoft debugger
+    'cspy', // IAR debugger
+    'mplab-core-da', // MPLAB debugger
+    'stlinkgdbtarget', // STMicroelectronics ST-Link debugger
+    'jlinkgdbtarget' // STMicroelectronics J-Link debugger
 ];
 
 export interface ITrackedDebugSession {


### PR DESCRIPTION
This PR adds support for STMicroelectronics ST-Link and J-Link adapters.

You can find these adapters in the following extensions:
https://marketplace.visualstudio.com/items?itemName=stmicroelectronics.stm32cube-ide-debug-stlink-gdbserver
https://marketplace.visualstudio.com/items?itemName=stmicroelectronics.stm32cube-ide-debug-jlink-gdbserver

Note: These extensions are included in the extensions pack "STM32CubeIDE for Visual Studio Code":
https://marketplace.visualstudio.com/items?itemName=stmicroelectronics.stm32-vscode-extension

Kind Regards,
Florent